### PR TITLE
add lua support to full install & merge old nginx configuration

### DIFF
--- a/debian/conf/modules-available/flavor-extras.conf
+++ b/debian/conf/modules-available/flavor-extras.conf
@@ -1,4 +1,3 @@
-load_module "modules/ngx_http_geoip_module.so";
 load_module "modules/ngx_http_image_filter_module.so";
 load_module "modules/ngx_http_xslt_filter_module.so";
 load_module "modules/ngx_mail_module.so";

--- a/debian/conf/modules-available/flavor-full.conf
+++ b/debian/conf/modules-available/flavor-full.conf
@@ -1,4 +1,3 @@
-load_module "modules/ngx_http_geoip_module.so";
 load_module "modules/ngx_http_image_filter_module.so";
 load_module "modules/ngx_http_xslt_filter_module.so";
 load_module "modules/ngx_mail_module.so";

--- a/debian/nginx-common.install
+++ b/debian/nginx-common.install
@@ -1,5 +1,1 @@
 debian/conf/* etc/nginx
-debian/ufw/nginx etc/ufw/applications.d
-html/index.html usr/share/nginx/html/
-debian/vim/nginx.yaml usr/share/vim/registry
-contrib/vim/* usr/share/vim/addons

--- a/debian/nginx-common.nginx.logrotate
+++ b/debian/nginx-common.nginx.logrotate
@@ -3,16 +3,15 @@
 	missingok
 	rotate 14
 	compress
-	delaycompress
 	notifempty
 	create 0640 www-data adm
 	sharedscripts
 	prerotate
 		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
 			run-parts /etc/logrotate.d/httpd-prerotate; \
-		fi \
+		fi; \
 	endscript
 	postrotate
-		invoke-rc.d nginx rotate >/dev/null 2>&1
+		[ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`
 	endscript
 }

--- a/debian/nginx-common.postinst
+++ b/debian/nginx-common.postinst
@@ -32,11 +32,6 @@ case "$1" in
       ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
     fi
 
-    # Create a default index page when not already present.
-    if [ ! -e /var/www/html/index.nginx-debian.html ]; then
-      cp /usr/share/nginx/html/index.html /var/www/html/index.nginx-debian.html
-    fi
-
     ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/nginx-common.upstart
+++ b/debian/nginx-common.upstart
@@ -1,4 +1,5 @@
 description "nginx http daemon"
+author "willem@byte.nl"
 
 start on (filesystem and net-device-up IFACE=lo)
 stop on runlevel [!2345]
@@ -7,26 +8,30 @@ env DAEMON=/usr/sbin/nginx
 env PID=/var/run/nginx.pid
 env DEFAULTFILE=/etc/default/nginx
 
-expect fork
 respawn
+respawn limit unlimited
 
 # syntax check
 pre-start script
-        $DAEMON -t
-        if [ $? -ne 0 ]
-                then exit $?
-        fi
+    $DAEMON -t
+    if [ $? -ne 0 ]
+            then exit $?
+    fi
+    # if there are dangling kids occupying our socket, slay them!
+    /bin/fuser --kill 80/tcp --verbose || /bin/true
 end script
 
-exec $DAEMON
+# daemon off, so upstart doesnt need to wait for fork
+# Otherwise, respawn does not work in case of occupied sockets
+# https://www.byte.nl/blog/?p=22570
+exec $DAEMON -g "daemon off;"
 
 # somewhat likely to get killed
-oom score 500
+oom score -200
 
 post-stop script
 	goal=$(initctl status $UPSTART_JOB | cut -d' ' -f 2 | cut -d/ -f 1)
 	if [ "$goal" != "stop" ]; then
-		sleep 10;
+		sleep 3;
 	fi
 end script
-

--- a/debian/nginx-common.upstart
+++ b/debian/nginx-common.upstart
@@ -1,0 +1,32 @@
+description "nginx http daemon"
+
+start on (filesystem and net-device-up IFACE=lo)
+stop on runlevel [!2345]
+
+env DAEMON=/usr/sbin/nginx
+env PID=/var/run/nginx.pid
+env DEFAULTFILE=/etc/default/nginx
+
+expect fork
+respawn
+
+# syntax check
+pre-start script
+        $DAEMON -t
+        if [ $? -ne 0 ]
+                then exit $?
+        fi
+end script
+
+exec $DAEMON
+
+# somewhat likely to get killed
+oom score 500
+
+post-stop script
+	goal=$(initctl status $UPSTART_JOB | cut -d' ' -f 2 | cut -d/ -f 1)
+	if [ "$goal" != "stop" ]; then
+		sleep 10;
+	fi
+end script
+

--- a/debian/nginx-full.install
+++ b/debian/nginx-full.install
@@ -1,2 +1,1 @@
 debian/build-full/objs/nginx usr/sbin
-debian/build-full/objs/*.so  usr/lib/nginx/modules

--- a/debian/rules
+++ b/debian/rules
@@ -69,34 +69,23 @@ light_configure_flags := \
 full_configure_flags := \
 			$(common_configure_flags) \
 			--with-http_addition_module \
-			--with-http_dav_module \
-			--with-http_geoip_module=dynamic \
+			--with-http_geoip_module \
 			--with-http_gunzip_module \
 			--with-http_gzip_static_module \
-			--with-http_image_filter_module=dynamic \
 			--with-http_v2_module \
 			--with-http_sub_module \
-			--with-http_xslt_module=dynamic \
-			--with-stream=dynamic \
-			--with-stream_ssl_module \
-			--with-mail=dynamic \
-			--with-mail_ssl_module \
 			--with-threads \
-			--add-module=$(MODULESDIR)/nginx-auth-pam \
-			--add-module=$(MODULESDIR)/nginx-dav-ext-module \
 			--add-module=$(MODULESDIR)/nginx-echo \
-			--add-module=$(MODULESDIR)/nginx-upstream-fair \
-			--add-module=$(MODULESDIR)/ngx_http_substitutions_filter_module
+			--add-module=$(MODULESDIR)/nginx-lua 
 
 extras_configure_flags := \
 			$(common_configure_flags) \
 			--with-http_addition_module \
 			--with-http_dav_module \
 			--with-http_flv_module \
-			--with-http_geoip_module=dynamic \
+			--with-http_geoip_module \
 			--with-http_gunzip_module \
 			--with-http_gzip_static_module \
-			--with-http_image_filter_module=dynamic \
 			--with-http_mp4_module \
 			--with-http_perl_module \
 			--with-http_random_index_module \
@@ -120,7 +109,7 @@ extras_configure_flags := \
 			--add-module=$(MODULESDIR)/nginx-lua \
 			--add-module=$(MODULESDIR)/nginx-upload-progress \
 			--add-module=$(MODULESDIR)/nginx-upstream-fair \
-			--add-module=$(MODULESDIR)/ngx_http_substitutions_filter_module
+			--add-module=$(MODULESDIR)/ngx_http_substitutions_filter_module 
 
 %:
 	dh $@


### PR DESCRIPTION
- strip some unused stuff like [here](https://github.com/ByteInternet/nginx-hypernode/pull/1/files)
- add nginx-lua to nginx-full
- statically build `--with-http_geoip_module=` because loading it dynamically as .so doesn't work for some reason and it doesn't really matter for us (we want the dynamic module loading future for adding modules without recompiling, not for removing them) 
