### PR TITLE
patch CVE-2016-1247

### DIFF
--- a/debian/nginx-common.config
+++ b/debian/nginx-common.config
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -e
+
+. /usr/share/debconf/confmodule
+
+logdir="/var/log/nginx"
+
+log_symlinks_check() {
+    # Skip new installations
+    [ -z "$1" ] && return
+
+    # Skip unaffected installations
+    dpkg --compare-versions "$1" lt-nl "1.10.2-1~" || return 0
+
+    # Check for unsecure symlinks
+    linked_logfiles="` find "$logdir" -type l -user www-data -name '*.log' `"
+
+    # Skip if nothing is found
+    [ -z "$linked_logfiles" ] && return
+
+    db_subst nginx/log-symlinks logfiles $linked_logfiles
+    db_input high nginx/log-symlinks || true
+    db_go || true
+}
+
+case "$1" in
+    configure|reconfigure)
+        log_symlinks_check "$2"
+        ;;
+    *)
+        ;;
+esac
+
+# vim: set ts=4 sts=4 sw=4 et sta ai :
+

--- a/debian/nginx-common.postinst
+++ b/debian/nginx-common.postinst
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+. /usr/share/debconf/confmodule
+
 # Handle naxsi removal
 dpkg-maintscript-helper rm_conffile \
 	          /etc/nginx/naxsi.rules         1.6.2-2~ -- "$@"
@@ -14,18 +16,31 @@ dpkg-maintscript-helper rm_conffile \
 case "$1" in
   configure)
     logdir="/var/log/nginx"
-    # Ensure secure permissions (CVE-2013-0337)
-    # http://bugs.debian.org/701112
-    #
-    # nginx uses 0755 for log files making them world readable,
-    # we fix that by using 0750 for the log directory.
-    #
-    # Allow local admin to override:
-    # e.g. dpkg-statoverride --add root adm 0755 /var/log/nginx
+
+    # Allow local admin to override
     if ! dpkg-statoverride --list "$logdir" >/dev/null; then
-      chown www-data:adm $logdir
-      chmod 0750 $logdir
+      chown root:adm $logdir
+      chmod 0755 $logdir
     fi
+
+    # Secure default logfiles on fresh installations
+    if [ -z "$2" ]; then
+      access_log="$logdir/access.log"
+      error_log="$logdir/error.log"
+
+      if [ ! -e "$access_log" ]; then
+        touch "$access_log"
+        chmod 640 "$access_log"
+        chown www-data:adm "$access_log"
+      fi
+
+      if [ ! -e "$error_log" ]; then
+        touch "$error_log"
+        chmod 640 "$error_log"
+        chown www-data:adm "$error_log"
+      fi
+    fi
+
     # If a symlink doesn't exist and can be created, then create it.
     if [ -z $2 ] && [ ! -e /etc/nginx/sites-enabled/default ] &&
        [ -d /etc/nginx/sites-enabled ] && [ -d /etc/nginx/sites-available ]; then

--- a/debian/nginx-common.templates
+++ b/debian/nginx-common.templates
@@ -1,0 +1,13 @@
+Template: nginx/log-symlinks
+Type: note
+_Description: Possible insecure nginx log files
+ The following log files under /var/log/nginx directory are symlinks
+ owned by www-data:
+ .
+ ${logfiles}
+ .
+ Since nginx 1.4.4-4 /var/log/nginx was owned by www-data. As a result
+ www-data could symlink log files to sensitive locations, which in turn
+ could lead to privilege escalation attacks. Although /var/log/nginx
+ permissions are now fixed it is possible that such insecure links
+ already exist. So, please make sure to check the above locations.

--- a/debian/po/POTFILES.in
+++ b/debian/po/POTFILES.in
@@ -1,0 +1,1 @@
+[type: gettext/rfc822deb] nginx-common.templates

--- a/debian/po/templates.pot
+++ b/debian/po/templates.pot
@@ -1,0 +1,49 @@
+# Nginx debconf translations
+# Copyright (C) 2016 Christos Trochalakis
+# This file is distributed under the same license as the nginx package.
+# Chrirtos Trochalakis <yatiohi@ideopolis.gr>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: nginx\n"
+"Report-Msgid-Bugs-To: nginx@packages.debian.org\n"
+"POT-Creation-Date: 2016-10-04 20:03+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Type: note
+#. Description
+#: ../nginx-common.templates:1001
+msgid "Possible insecure nginx log files"
+msgstr ""
+
+#. Type: note
+#. Description
+#: ../nginx-common.templates:1001
+msgid ""
+"The following log files under /var/log/nginx directory are symlinks owned by "
+"www-data:"
+msgstr ""
+
+#. Type: note
+#. Description
+#: ../nginx-common.templates:1001
+msgid "${logfiles}"
+msgstr ""
+
+#. Type: note
+#. Description
+#: ../nginx-common.templates:1001
+msgid ""
+"Since nginx 1.4.4-4 /var/log/nginx was owned by www-data. As a result www-"
+"data could symlink log files to sensitive locations, which in turn could "
+"lead to privilege escalation attacks. Although /var/log/nginx permissions "
+"are now fixed it is possible that such insecure links already exist. So, "
+"please make sure to check the above locations."
+msgstr ""


### PR DESCRIPTION
https://anonscm.debian.org/cgit/collab-maint/nginx.git/commit/?id=333595dc8382e728bc9d57c1e533fa656b2fd6b3

When we upgrade to Ubuntu 16 we're gonna overhaul the nginx packaging anyway so instead of catching up with the latest remote master I've cherrypicked some diffs from the d36950ed63845eaacdc3ca4ca82effc8f67fc416 commit of collab-maint/nginx https://anonscm.debian.org/cgit/collab-maint/nginx.git